### PR TITLE
Commit lock file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,1 @@
 target
-Ballerina.lock

--- a/Ballerina.lock
+++ b/Ballerina.lock
@@ -1,0 +1,9 @@
+org_name = "sanjiva"
+version = "0.1.0"
+lockfile_version = "1.0.0"
+ballerina_version = "1.2.4"
+
+[[imports."sanjiva/service:0.1.0"]]
+org_name = "chamil"
+name = "govsms"
+version = "0.1.2"


### PR DESCRIPTION
The GovSMS client has a newer version with a bulk API. We don't need that for now so binding to the older version to avoid using new one.